### PR TITLE
Bug: fixed bug where anchor link dose not go to about section

### DIFF
--- a/src/components/About.jsx
+++ b/src/components/About.jsx
@@ -8,7 +8,7 @@ const About = () => {
   const [count, setCount] = useState(0);
 
   return (
-    <div className="about-section" data-aos="fade-up">
+    <div className="about-section" data-aos="fade-up" id="about">
       <h1 className="text-yellow-300" id="about-title">About Me</h1>
 
       <div className="about-content">

--- a/src/styles.css
+++ b/src/styles.css
@@ -106,6 +106,10 @@ h1 {
   border: greenyellow solid 5px;
 }
 
+#about {
+  scroll-margin-top: 100px;
+}
+
 #about-title {
   font-size: 50px;
   text-align: center;


### PR DESCRIPTION
## Description 
The navigation bar has an anchor link "About" that links to the about section of the landing page. However clicking it displays the middle of the "Technical Skills" and "About" section rather than the top of "About section". Added scroll-margin-top with a value of 100px to ensure it works as it should. 